### PR TITLE
Make this fork compatible with TYPO3 8.7.9 

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -845,7 +845,7 @@ class GeneralUtility implements SingletonInterface
         $GLOBALS['TSFE']->fe_user->fetchGroupData();
 
         // Include the TCA
-        \TYPO3\CMS\Core\Core\Bootstrap::getInstance()->loadCachedTca();
+        \TYPO3\CMS\Frontend\Utility\EidUtility::initTCA() ;
 
         // Get the page
         $GLOBALS['TSFE']->fetch_the_id();

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"psr-4": {
 			"Typoheads\\Formhandler\\": "Classes"
 		},
-		"classmap": ["Resources/PHP/tcpdf/tcpdf.php","Resources/PHP/filtreatment"]
+		"classmap" : ["Resources/PHP/tcpdf/tcpdf.php", "Resources/PHP/filtreatment", "pi1"]
 	},
 	"replace": {
 		"formhandler": "self.version",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.4.1',
     'constraints' => [
         'depends' => [
-            'php' => '5.5.0-7.1.0',
+            'php' => '5.5.0-7.1.99',
             'typo3' => '7.6.0-8.7.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
Simply includes pi1 on the composer.json autoload classmap and remove an outdated call to TCA init. 